### PR TITLE
Assortment of small changes

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::error::ErrorMatch;
 use crate::pattern::{all_patterns, pattern};
 use std::cmp::{max, min};
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Metadata {
     title: String,
     season: Option<i32>,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -42,7 +42,7 @@ impl Metadata {
             });
         }
 
-        if title_start > title_end {
+        if title_start >= title_end {
             return Err(ErrorMatch::new(captures));
         }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -65,7 +65,7 @@ const ALL_RAW_PATTERNS: [(&'static str, &'static str); 18] = [
         "quality",
         r"(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV )?WEB-?DL(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDRIP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv",
     ),
-    ("codec", r"[Xx][Vv][Ii][Dd]|x264|[hH]\.?264/?"),
+    ("codec", r"[Xx][Vv][Ii][Dd]|[Xx]264|[hH]\.?264/|[Xx]265|[Hh]\.?265|[Hh][Ee][Vv][Cc]?"),
     (
         "audio",
         r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?",


### PR DESCRIPTION
This does a few things
* Derives `Clone` and `Default` for `Metadata` - simple usability stuff for structs that embed `Metadata`
* Fixes an issue where `Metadata::from()` would panic with an underflow bounds check
* Adds x265/H.265/HEVC support to the `codec` regex

Cheers :)