### PR TITLE
Another small round of speed-ups

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,15 @@
+use crate::pattern::PatternName;
 use regex::Match;
 use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
 pub struct ErrorMatch<'t> {
-    matches: Vec<(&'static str, Option<Match<'t>>)>,
+    matches: Vec<(PatternName, Option<Match<'t>>)>,
 }
 
 impl<'t> ErrorMatch<'t> {
-    pub fn new(matches: Vec<(&'static str, Option<Match<'t>>)>) -> ErrorMatch<'t> {
+    pub fn new(matches: Vec<(PatternName, Option<Match<'t>>)>) -> ErrorMatch<'t> {
         ErrorMatch { matches }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,24 @@
-use crate::pattern::PatternName;
-use regex::Match;
 use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
-pub struct ErrorMatch<'t> {
-    matches: Vec<(PatternName, Option<Match<'t>>)>,
+pub struct ErrorMatch {
+    matches: Vec<(&'static str, Option<String>)>,
 }
 
-impl<'t> ErrorMatch<'t> {
-    pub fn new(matches: Vec<(PatternName, Option<Match<'t>>)>) -> ErrorMatch<'t> {
+impl ErrorMatch {
+    pub fn new(matches: Vec<(&'static str, Option<String>)>) -> ErrorMatch {
         ErrorMatch { matches }
     }
 }
 
-impl fmt::Display for ErrorMatch<'_> {
+impl fmt::Display for ErrorMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.matches)
     }
 }
 
-impl Error for ErrorMatch<'_> {
+impl Error for ErrorMatch {
     fn description(&self) -> &str {
         "Couldn't find a title."
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,5 +1,5 @@
 use crate::error::ErrorMatch;
-use crate::pattern::all_patterns;
+use crate::pattern::{PatternName, PATTERNS};
 use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::collections::HashMap;
@@ -30,9 +30,8 @@ impl Metadata {
         let mut title_start = 0;
         let mut title_end = name.len();
 
-        let patterns = all_patterns().collect::<Vec<_>>();
-        let mut captures = HashMap::with_capacity(patterns.len());
-        for (pname, p) in patterns {
+        let mut captures = HashMap::with_capacity(PATTERNS.len());
+        for (pname, p) in PATTERNS.iter() {
             if let Some(m) = p.captures(name) {
                 if let Some(cap) = m.get(0) {
                     if p.before_title() {
@@ -68,14 +67,14 @@ impl Metadata {
             .trim()
             .to_string();
 
-        let season = captures.get("season").and_then(|caps| {
+        let season = captures.get(&PatternName::Season).and_then(|caps| {
             caps.name("short")
                 .or_else(|| caps.name("long"))
                 .or_else(|| caps.name("dash"))
                 .map(|m| m.as_str())
                 .map(|s| s.parse().unwrap())
         });
-        let episode = captures.get("episode").and_then(|caps| {
+        let episode = captures.get(&PatternName::Episode).and_then(|caps| {
             caps.name("short")
                 .or_else(|| caps.name("long"))
                 .or_else(|| caps.name("cross"))
@@ -83,37 +82,37 @@ impl Metadata {
                 .map(|m| m.as_str())
                 .map(|s| s.parse().unwrap())
         });
-        let year = captures.get("year").and_then(|caps| {
+        let year = captures.get(&PatternName::Year).and_then(|caps| {
             caps.name("year")
                 .map(|m| m.as_str())
                 .map(|s| s.parse().unwrap())
         });
         let resolution = captures
-            .get("resolution")
+            .get(&PatternName::Resolution)
             .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()));
         let quality = captures
-            .get("quality")
+            .get(&PatternName::Quality)
             .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
         let codec = captures
-            .get("codec")
+            .get(&PatternName::Codec)
             .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
         let audio = captures
-            .get("audio")
+            .get(&PatternName::Audio)
             .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
         let group = captures
-            .get("group")
+            .get(&PatternName::Group)
             .and_then(|caps| caps.get(2).map(|m| m.as_str().to_string()));
         let imdb = captures
-            .get("imdb")
+            .get(&PatternName::Imdb)
             .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
 
-        let extended = captures.contains_key("extended");
-        let hardcoded = captures.contains_key("hardcoded");
-        let proper = captures.contains_key("proper");
-        let repack = captures.contains_key("repack");
-        let widescreen = captures.contains_key("widescreen");
-        let unrated = captures.contains_key("unrated");
-        let three_d = captures.contains_key("three_d");
+        let extended = captures.contains_key(&PatternName::Extended);
+        let hardcoded = captures.contains_key(&PatternName::Hardcoded);
+        let proper = captures.contains_key(&PatternName::Proper);
+        let repack = captures.contains_key(&PatternName::Repack);
+        let widescreen = captures.contains_key(&PatternName::Widescreen);
+        let unrated = captures.contains_key(&PatternName::Unrated);
+        let three_d = captures.contains_key(&PatternName::ThreeD);
 
         Ok(Metadata {
             title,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,8 +1,9 @@
 use crate::error::ErrorMatch;
-use crate::pattern::{PatternName, PATTERNS};
+use crate::pattern;
+use crate::pattern::Pattern;
+use regex::Captures;
 use std::borrow::Cow;
 use std::cmp::{max, min};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Metadata {
@@ -25,29 +26,174 @@ pub struct Metadata {
     imdb: Option<String>,
 }
 
+fn check_pattern_and_extract<'a>(
+    pattern: &Pattern,
+    torrent_name: &'a str,
+    title_start: &mut usize,
+    title_end: &mut usize,
+    extract_value: impl Fn(Captures<'a>) -> Option<&'a str>,
+) -> Option<&'a str> {
+    pattern.captures(torrent_name).and_then(|caps| {
+        if let Some(cap) = caps.get(0) {
+            if pattern.before_title() {
+                *title_start = max(*title_start, cap.end());
+            } else {
+                *title_end = min(*title_end, cap.start());
+            }
+        }
+        extract_value(caps)
+    })
+}
+
+fn check_pattern<'a>(
+    pattern: &Pattern,
+    torrent_name: &'a str,
+    title_start: &mut usize,
+    title_end: &mut usize,
+) -> Option<Captures<'a>> {
+    pattern.captures(torrent_name).map(|caps| {
+        if let Some(cap) = caps.get(0) {
+            if pattern.before_title() {
+                *title_start = max(*title_start, cap.end());
+            } else {
+                *title_end = min(*title_end, cap.start());
+            }
+        }
+        caps
+    })
+}
+
+fn capture_to_string(caps: Option<Captures<'_>>) -> Option<String> {
+    caps.and_then(|c| c.get(0)).map(|m| m.as_str().to_string())
+}
+
 impl Metadata {
     pub fn from(name: &str) -> Result<Self, ErrorMatch> {
         let mut title_start = 0;
         let mut title_end = name.len();
 
-        let mut captures = HashMap::with_capacity(PATTERNS.len());
-        for (pname, p) in PATTERNS.iter() {
-            if let Some(m) = p.captures(name) {
-                if let Some(cap) = m.get(0) {
-                    if p.before_title() {
-                        title_start = max(title_start, cap.end());
-                    } else {
-                        title_end = min(title_end, cap.start());
-                    }
-                }
-                captures.insert(*pname, m);
-            }
-        }
+        let season = check_pattern_and_extract(
+            &pattern::SEASON,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| {
+                caps.name("short")
+                    .or_else(|| caps.name("long"))
+                    .or_else(|| caps.name("dash"))
+                    .map(|m| m.as_str())
+            },
+        );
+
+        let episode = check_pattern_and_extract(
+            &pattern::EPISODE,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| {
+                caps.name("short")
+                    .or_else(|| caps.name("long"))
+                    .or_else(|| caps.name("cross"))
+                    .or_else(|| caps.name("dash"))
+                    .map(|m| m.as_str())
+            },
+        );
+
+        let year = check_pattern_and_extract(
+            &pattern::YEAR,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps: Captures<'_>| caps.name("year").map(|m| m.as_str()),
+        );
+
+        let resolution = check_pattern_and_extract(
+            &pattern::RESOLUTION,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(1).map(|m| m.as_str()),
+        )
+        .map(String::from);
+        let quality = check_pattern_and_extract(
+            &pattern::QUALITY,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(0).map(|m| m.as_str()),
+        )
+        .map(String::from);
+        let codec = check_pattern_and_extract(
+            &pattern::CODEC,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(0).map(|m| m.as_str()),
+        )
+        .map(String::from);
+        let audio = check_pattern_and_extract(
+            &pattern::AUDIO,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(0).map(|m| m.as_str()),
+        )
+        .map(String::from);
+        let group = check_pattern_and_extract(
+            &pattern::GROUP,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(2).map(|m| m.as_str()),
+        )
+        .map(String::from);
+        let imdb = check_pattern_and_extract(
+            &pattern::IMDB,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(0).map(|m| m.as_str()),
+        )
+        .map(String::from);
+
+        let extended = check_pattern(&pattern::EXTENDED, name, &mut title_start, &mut title_end);
+        let hardcoded = check_pattern(&pattern::HARDCODED, name, &mut title_start, &mut title_end);
+        let proper = check_pattern(&pattern::PROPER, name, &mut title_start, &mut title_end);
+        let repack = check_pattern(&pattern::REPACK, name, &mut title_start, &mut title_end);
+        let widescreen =
+            check_pattern(&pattern::WIDESCREEN, name, &mut title_start, &mut title_end);
+        let unrated = check_pattern(&pattern::UNRATED, name, &mut title_start, &mut title_end);
+        let three_d = check_pattern(&pattern::THREE_D, name, &mut title_start, &mut title_end);
+
+        let region = check_pattern(&pattern::REGION, name, &mut title_start, &mut title_end);
+        let container = check_pattern(&pattern::CONTAINER, name, &mut title_start, &mut title_end);
+        let language = check_pattern(&pattern::LANGUAGE, name, &mut title_start, &mut title_end);
+        let garbage = check_pattern(&pattern::GARBAGE, name, &mut title_start, &mut title_end);
+        let website = check_pattern(&pattern::WEBSITE, name, &mut title_start, &mut title_end);
 
         if title_start >= title_end {
-            return Err(ErrorMatch::new(
-                captures.into_iter().map(|(k, v)| (k, v.get(0))).collect(),
-            ));
+            return Err(ErrorMatch::new(vec![
+                ("season", season.map(String::from)),
+                ("episode", episode.map(String::from)),
+                ("year", year.map(String::from)),
+                ("resolution", resolution),
+                ("quality", quality),
+                ("codec", codec),
+                ("audio", audio),
+                ("group", group),
+                ("imdb", imdb),
+                ("extended", capture_to_string(extended)),
+                ("proper", capture_to_string(proper)),
+                ("repack", capture_to_string(repack)),
+                ("widescreen", capture_to_string(widescreen)),
+                ("unrated", capture_to_string(unrated)),
+                ("three_d", capture_to_string(three_d)),
+                ("region", capture_to_string(region)),
+                ("container", capture_to_string(container)),
+                ("language", capture_to_string(language)),
+                ("garbage", capture_to_string(garbage)),
+                ("website", capture_to_string(website)),
+            ]));
         }
 
         let mut title = &name[title_start..title_end];
@@ -67,70 +213,23 @@ impl Metadata {
             .trim()
             .to_string();
 
-        let season = captures.get(&PatternName::Season).and_then(|caps| {
-            caps.name("short")
-                .or_else(|| caps.name("long"))
-                .or_else(|| caps.name("dash"))
-                .map(|m| m.as_str())
-                .map(|s| s.parse().unwrap())
-        });
-        let episode = captures.get(&PatternName::Episode).and_then(|caps| {
-            caps.name("short")
-                .or_else(|| caps.name("long"))
-                .or_else(|| caps.name("cross"))
-                .or_else(|| caps.name("dash"))
-                .map(|m| m.as_str())
-                .map(|s| s.parse().unwrap())
-        });
-        let year = captures.get(&PatternName::Year).and_then(|caps| {
-            caps.name("year")
-                .map(|m| m.as_str())
-                .map(|s| s.parse().unwrap())
-        });
-        let resolution = captures
-            .get(&PatternName::Resolution)
-            .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()));
-        let quality = captures
-            .get(&PatternName::Quality)
-            .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
-        let codec = captures
-            .get(&PatternName::Codec)
-            .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
-        let audio = captures
-            .get(&PatternName::Audio)
-            .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
-        let group = captures
-            .get(&PatternName::Group)
-            .and_then(|caps| caps.get(2).map(|m| m.as_str().to_string()));
-        let imdb = captures
-            .get(&PatternName::Imdb)
-            .and_then(|caps| caps.get(0).map(|m| m.as_str().to_string()));
-
-        let extended = captures.contains_key(&PatternName::Extended);
-        let hardcoded = captures.contains_key(&PatternName::Hardcoded);
-        let proper = captures.contains_key(&PatternName::Proper);
-        let repack = captures.contains_key(&PatternName::Repack);
-        let widescreen = captures.contains_key(&PatternName::Widescreen);
-        let unrated = captures.contains_key(&PatternName::Unrated);
-        let three_d = captures.contains_key(&PatternName::ThreeD);
-
         Ok(Metadata {
             title,
-            season,
-            episode,
-            year,
+            season: season.map(|s| s.parse().unwrap()),
+            episode: episode.map(|s| s.parse().unwrap()),
+            year: year.map(|s| s.parse().unwrap()),
             resolution,
             quality,
             codec,
             audio,
             group,
-            extended,
-            hardcoded,
-            proper,
-            repack,
-            widescreen,
-            unrated,
-            three_d,
+            extended: extended.is_some(),
+            hardcoded: hardcoded.is_some(),
+            proper: proper.is_some(),
+            repack: repack.is_some(),
+            widescreen: widescreen.is_some(),
+            unrated: unrated.is_some(),
+            three_d: three_d.is_some(),
             imdb,
         })
     }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,5 +1,4 @@
 use regex::{Captures, Regex};
-use std::convert::TryInto;
 use std::iter::Iterator;
 
 #[derive(Debug)]
@@ -88,82 +87,34 @@ impl Pattern {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum PatternName {
-    Season,
-    Episode,
-    Resolution,
-    Quality,
-    Codec,
-    Audio,
-    Group,
-    Region,
-    Extended,
-    Hardcoded,
-    Proper,
-    Repack,
-    Container,
-    Widescreen,
-    ThreeD,
-    Unrated,
-    Language,
-    Garbage,
-    Imdb,
-    Year,
-    Website,
-}
-
-const ALL_RAW_PATTERNS: [(PatternName, &str); 19] = [
-    (
-        PatternName::Season,
-        r"[Ss]?(?P<short>\d+) ?[Eex]|(Season|SEASON)(?:[^\d]|$)(?P<long>\d+)|S(?P<dash>\d+) - \d+",
-    ),
-    (
-        PatternName::Episode,
-        r"[Ee](?P<short>\d+)(?:[^\d]|$)|(Episode|EPISODE)(?:[^\d]|$)(?P<long>\d+)|\d+x(?P<cross>\d+)|S\d+ - (?P<dash>\d+)",
-    ),
-    (PatternName::Resolution, r"((\d{3,4}p))[^M]"),
-    (
-        PatternName::Quality,
-        r"(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV )?WEB-?(DL)?(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDRIP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv",
-    ),
-    (
-        PatternName::Codec,
-        r"[Xx][Vv][Ii][Dd]|[Xx]264|[hH]\.?264/?|[Xx]265|[Hh]\.?265|[Hh][Ee][Vv][Cc]?",
-    ),
-    (
-        PatternName::Audio,
-        r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?",
-    ),
-    (PatternName::Group, r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$"),
-    (PatternName::Region, r"R\d"),
-    (PatternName::Extended, r"EXTENDED"),
-    (PatternName::Hardcoded, r"HC"),
-    (PatternName::Proper, r"PROPER"),
-    (PatternName::Repack, r"REPACK"),
-    (PatternName::Container, r"MKV|AVI"),
-    (PatternName::Widescreen, r"WS"),
-    (PatternName::ThreeD, r"3D"),
-    (PatternName::Unrated, r"UNRATED"),
-    (PatternName::Language, r"rus\.eng|US"),
-    (PatternName::Garbage, r"1400Mb|3rd Nov|((Rip)) "),
-    (PatternName::Imdb, r"tt\d{7}"),
-];
-
 lazy_static! {
-    pub static ref PATTERNS: [(PatternName, Pattern); 21] = {
-        let mut bucket: Vec<_> = ALL_RAW_PATTERNS
-            .iter()
-            .map(|(name, regex)| (*name, regex!(regex)))
-            .collect();
-        bucket.push((
-            PatternName::Year,
-            regex!(r"(?P<year>(1[89]|20)\d\d)", false, true, true),
-        ));
-        bucket.push((
-            PatternName::Website,
-            regex!(r"^(\[ ?([^\]]+?) ?\]) ?", true, false, false),
-        ));
-        bucket.try_into().unwrap()
-    };
+    pub static ref SEASON: Pattern = regex!(
+        r"[Ss]?(?P<short>\d+) ?[Eex]|(Season|SEASON)(?:[^\d]|$)(?P<long>\d+)|S(?P<dash>\d+) - \d+"
+    );
+    pub static ref EPISODE: Pattern = regex!(
+        r"[Ee](?P<short>\d+)(?:[^\d]|$)|(Episode|EPISODE)(?:[^\d]|$)(?P<long>\d+)|\d+x(?P<cross>\d+)|S\d+ - (?P<dash>\d+)"
+    );
+    pub static ref RESOLUTION: Pattern = regex!(r"((\d{3,4}p))[^M]");
+    pub static ref QUALITY: Pattern = regex!(
+        r"(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV )?WEB-?(DL)?(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDRIP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv"
+    );
+    pub static ref CODEC: Pattern =
+        regex!(r"[Xx][Vv][Ii][Dd]|[Xx]264|[hH]\.?264/?|[Xx]265|[Hh]\.?265|[Hh][Ee][Vv][Cc]?");
+    pub static ref AUDIO: Pattern =
+        regex!(r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?");
+    pub static ref GROUP: Pattern = regex!(r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$");
+    pub static ref REGION: Pattern = regex!(r"R\d");
+    pub static ref EXTENDED: Pattern = regex!(r"EXTENDED");
+    pub static ref HARDCODED: Pattern = regex!(r"HC");
+    pub static ref PROPER: Pattern = regex!(r"PROPER");
+    pub static ref REPACK: Pattern = regex!(r"REPACK");
+    pub static ref CONTAINER: Pattern = regex!(r"MKV|AVI");
+    pub static ref WIDESCREEN: Pattern = regex!(r"WS");
+    pub static ref THREE_D: Pattern = regex!(r"3D");
+    pub static ref UNRATED: Pattern = regex!(r"UNRATED");
+    pub static ref LANGUAGE: Pattern = regex!(r"rus\.eng|US");
+    pub static ref GARBAGE: Pattern = regex!(r"1400Mb|3rd Nov|((Rip)) ");
+    pub static ref IMDB: Pattern = regex!(r"tt\d{7}");
+    pub static ref YEAR: Pattern = regex!(r"(?P<year>(1[89]|20)\d\d)", false, true, true);
+    pub static ref WEBSITE: Pattern = regex!(r"^(\[ ?([^\]]+?) ?\]) ?", true, false, false);
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,5 +1,5 @@
 use regex::{Captures, Regex};
-use std::collections::HashMap;
+use std::convert::TryInto;
 use std::iter::Iterator;
 
 #[derive(Debug)]
@@ -11,20 +11,17 @@ pub struct Pattern {
 }
 
 macro_rules! regex {
-    ($mapping:expr, $name:expr, $pattern:expr, $before_title:expr, $capture_last:expr, $no_numbers_surrounding:expr) => {
-        $mapping.insert(
-            $name,
-            Pattern::new(
-                Regex::new($pattern).unwrap(),
-                $before_title,
-                $capture_last,
-                $no_numbers_surrounding,
-            ),
+    ($pattern:expr, $before_title:expr, $capture_last:expr, $no_numbers_surrounding:expr) => {
+        Pattern::new(
+            Regex::new($pattern).unwrap(),
+            $before_title,
+            $capture_last,
+            $no_numbers_surrounding,
         )
     };
 
-    ($mapping:expr, $name:expr, $pattern:expr) => {
-        regex!($mapping, $name, $pattern, false, false, false);
+    ($pattern:expr) => {
+        regex!($pattern, false, false, false)
     };
 }
 
@@ -91,73 +88,82 @@ impl Pattern {
     }
 }
 
-pub fn all_patterns() -> impl Iterator<Item = (&'static &'static str, &'static Pattern)> {
-    PATTERNS.iter()
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum PatternName {
+    Season,
+    Episode,
+    Resolution,
+    Quality,
+    Codec,
+    Audio,
+    Group,
+    Region,
+    Extended,
+    Hardcoded,
+    Proper,
+    Repack,
+    Container,
+    Widescreen,
+    ThreeD,
+    Unrated,
+    Language,
+    Garbage,
+    Imdb,
+    Year,
+    Website,
 }
 
-const ALL_RAW_PATTERNS: [(&str, &str); 19] = [
+const ALL_RAW_PATTERNS: [(PatternName, &str); 19] = [
     (
-        "season",
+        PatternName::Season,
         r"[Ss]?(?P<short>\d+) ?[Eex]|(Season|SEASON)(?:[^\d]|$)(?P<long>\d+)|S(?P<dash>\d+) - \d+",
     ),
     (
-        "episode",
+        PatternName::Episode,
         r"[Ee](?P<short>\d+)(?:[^\d]|$)|(Episode|EPISODE)(?:[^\d]|$)(?P<long>\d+)|\d+x(?P<cross>\d+)|S\d+ - (?P<dash>\d+)",
     ),
-    ("resolution", r"((\d{3,4}p))[^M]"),
+    (PatternName::Resolution, r"((\d{3,4}p))[^M]"),
     (
-        "quality",
+        PatternName::Quality,
         r"(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV )?WEB-?(DL)?(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDRIP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv",
     ),
     (
-        "codec",
+        PatternName::Codec,
         r"[Xx][Vv][Ii][Dd]|[Xx]264|[hH]\.?264/?|[Xx]265|[Hh]\.?265|[Hh][Ee][Vv][Cc]?",
     ),
     (
-        "audio",
+        PatternName::Audio,
         r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?",
     ),
-    ("group", r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$"),
-    ("region", r"R\d"),
-    ("extended", r"EXTENDED"),
-    ("hardcoded", r"HC"),
-    ("proper", r"PROPER"),
-    ("repack", r"REPACK"),
-    ("container", r"MKV|AVI"),
-    ("widescreen", r"WS"),
-    ("three_d", r"3D"),
-    ("unrated", r"UNRATED"),
-    ("language", r"rus\.eng|US"),
-    ("garbage", r"1400Mb|3rd Nov|((Rip)) "),
-    ("imdb", r"tt\d{7}"),
+    (PatternName::Group, r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$"),
+    (PatternName::Region, r"R\d"),
+    (PatternName::Extended, r"EXTENDED"),
+    (PatternName::Hardcoded, r"HC"),
+    (PatternName::Proper, r"PROPER"),
+    (PatternName::Repack, r"REPACK"),
+    (PatternName::Container, r"MKV|AVI"),
+    (PatternName::Widescreen, r"WS"),
+    (PatternName::ThreeD, r"3D"),
+    (PatternName::Unrated, r"UNRATED"),
+    (PatternName::Language, r"rus\.eng|US"),
+    (PatternName::Garbage, r"1400Mb|3rd Nov|((Rip)) "),
+    (PatternName::Imdb, r"tt\d{7}"),
 ];
 
 lazy_static! {
-    static ref PATTERNS: HashMap<&'static str, Pattern> = {
-        let mut bucket = HashMap::new();
-
-        for (name, pattern) in &ALL_RAW_PATTERNS {
-            regex!(bucket, *name, pattern);
-        }
-
-        regex!(
-            bucket,
-            "year",
-            r"(?P<year>(1[89]|20)\d\d)",
-            false,
-            true,
-            true
-        );
-
-        regex!(
-            bucket,
-            "website",
-            r"^(\[ ?([^\]]+?) ?\]) ?",
-            true,
-            false,
-            false
-        );
-
-        bucket
+    pub static ref PATTERNS: [(PatternName, Pattern); 21] = {
+        let mut bucket: Vec<_> = ALL_RAW_PATTERNS
+            .iter()
+            .map(|(name, regex)| (*name, regex!(regex)))
+            .collect();
+        bucket.push((
+            PatternName::Year,
+            regex!(r"(?P<year>(1[89]|20)\d\d)", false, true, true),
+        ));
+        bucket.push((
+            PatternName::Website,
+            regex!(r"^(\[ ?([^\]]+?) ?\]) ?", true, false, false),
+        ));
+        bucket.try_into().unwrap()
     };
 }


### PR DESCRIPTION
This one is _reasonably_ uninvasive as well. It replaces the `&'static str` pattern names with an enum, replaces the `HashMap` with a static array, and eliminates the function call to produce an iterator.  7.2% in the realistic names benchmark :)

Invasive one coming next.  I expect that to be a far smaller difference.