### PR TITLE
Implement FromStr trait and call trait in Metadata::from

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,12 +3,33 @@ extern crate torrent_name_parser;
 use torrent_name_parser::Metadata;
 
 pub fn main() {
-    let m = Metadata::from("Euphoria.US.S01E03.Made.You.Look.1080p.AMZN.WEB-DL.DDP5.1.H.264-KiNGS")
+    if let Ok(m) =
+        Metadata::from("Euphoria.US.S01E03.Made.You.Look.1080p.AMZN.WEB-DL.DDP5.1.H.264-KiNGS")
+    {
+        println!(
+            "{}, Season {}, Episode {}",
+            m.title(),
+            m.season().unwrap(),
+            m.episode().unwrap()
+        );
+    }
+    if let Ok(m) =
+        "Marvels Agents of S.H.I.E.L.D. S01E06 HDTV x264-KILLERS[ettv]".parse::<Metadata>()
+    {
+        println!(
+            "{}, Season {}, Episode {}",
+            m.title(),
+            m.season().unwrap(),
+            m.episode().unwrap()
+        );
+    }
+    let m3: Metadata = "Marvels Agents of S.H.I.E.L.D. S02E06 HDTV x264-KILLERS[ettv]"
+        .parse()
         .unwrap();
     println!(
         "{}, Season {}, Episode {}",
-        m.title(),
-        m.season().unwrap(),
-        m.episode().unwrap()
+        m3.title(),
+        m3.season().unwrap(),
+        m3.episode().unwrap()
     );
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -77,13 +77,13 @@ impl Metadata {
     pub fn title(&self) -> &str {
         &self.title
     }
-    pub fn season(&self) -> Option<u32> {
+    pub fn season(&self) -> Option<i32> {
         self.season
     }
-    pub fn episode(&self) -> Option<u32> {
+    pub fn episode(&self) -> Option<i32> {
         self.episode
     }
-    pub fn year(&self) -> Option<u32> {
+    pub fn year(&self) -> Option<i32> {
         self.year
     }
     pub fn resolution(&self) -> Option<&str> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,12 +5,14 @@ use regex::Captures;
 use std::borrow::Cow;
 use std::cmp::{max, min};
 
+use std::{convert::TryFrom, str::FromStr};
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Metadata {
     title: String,
-    season: Option<i32>,
-    episode: Option<i32>,
-    year: Option<i32>,
+    season: Option<u32>,
+    episode: Option<u32>,
+    year: Option<u32>,
     resolution: Option<String>,
     quality: Option<String>,
     codec: Option<String>,
@@ -69,6 +71,66 @@ fn capture_to_string(caps: Option<Captures<'_>>) -> Option<String> {
 
 impl Metadata {
     pub fn from(name: &str) -> Result<Self, ErrorMatch> {
+        Metadata::from_str(name)
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+    pub fn season(&self) -> Option<u32> {
+        self.season
+    }
+    pub fn episode(&self) -> Option<u32> {
+        self.episode
+    }
+    pub fn year(&self) -> Option<u32> {
+        self.year
+    }
+    pub fn resolution(&self) -> Option<&str> {
+        self.resolution.as_deref()
+    }
+    pub fn quality(&self) -> Option<&str> {
+        self.quality.as_deref()
+    }
+    pub fn codec(&self) -> Option<&str> {
+        self.codec.as_deref()
+    }
+    pub fn audio(&self) -> Option<&str> {
+        self.audio.as_deref()
+    }
+    pub fn group(&self) -> Option<&str> {
+        self.group.as_deref()
+    }
+    pub fn imdb_tag(&self) -> Option<&str> {
+        self.imdb.as_deref()
+    }
+    pub fn extended(&self) -> bool {
+        self.extended
+    }
+    pub fn hardcoded(&self) -> bool {
+        self.hardcoded
+    }
+    pub fn proper(&self) -> bool {
+        self.proper
+    }
+    pub fn repack(&self) -> bool {
+        self.repack
+    }
+    pub fn widescreen(&self) -> bool {
+        self.widescreen
+    }
+    pub fn unrated(&self) -> bool {
+        self.unrated
+    }
+    pub fn three_d(&self) -> bool {
+        self.three_d
+    }
+}
+
+impl FromStr for Metadata {
+    type Err = ErrorMatch;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
         let mut title_start = 0;
         let mut title_end = name.len();
 
@@ -233,56 +295,12 @@ impl Metadata {
             imdb,
         })
     }
+}
 
-    pub fn title(&self) -> &str {
-        &self.title
-    }
-    pub fn season(&self) -> Option<i32> {
-        self.season
-    }
-    pub fn episode(&self) -> Option<i32> {
-        self.episode
-    }
-    pub fn year(&self) -> Option<i32> {
-        self.year
-    }
-    pub fn resolution(&self) -> Option<&str> {
-        self.resolution.as_deref()
-    }
-    pub fn quality(&self) -> Option<&str> {
-        self.quality.as_deref()
-    }
-    pub fn codec(&self) -> Option<&str> {
-        self.codec.as_deref()
-    }
-    pub fn audio(&self) -> Option<&str> {
-        self.audio.as_deref()
-    }
-    pub fn group(&self) -> Option<&str> {
-        self.group.as_deref()
-    }
-    pub fn imdb_tag(&self) -> Option<&str> {
-        self.imdb.as_deref()
-    }
-    pub fn extended(&self) -> bool {
-        self.extended
-    }
-    pub fn hardcoded(&self) -> bool {
-        self.hardcoded
-    }
-    pub fn proper(&self) -> bool {
-        self.proper
-    }
-    pub fn repack(&self) -> bool {
-        self.repack
-    }
-    pub fn widescreen(&self) -> bool {
-        self.widescreen
-    }
-    pub fn unrated(&self) -> bool {
-        self.unrated
-    }
-    pub fn three_d(&self) -> bool {
-        self.three_d
+impl TryFrom<&str> for Metadata {
+    type Error = ErrorMatch;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Metadata::from_str(s)
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -10,9 +10,9 @@ use std::{convert::TryFrom, str::FromStr};
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Metadata {
     title: String,
-    season: Option<u32>,
-    episode: Option<u32>,
-    year: Option<u32>,
+    season: Option<i32>,
+    episode: Option<i32>,
+    year: Option<i32>,
     resolution: Option<String>,
     quality: Option<String>,
     codec: Option<String>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -345,6 +345,32 @@ fn names() {
     assert_eq!(m.year(), Some(2011));
 }
 
+#[cfg(test)]
+mod parse {
+    use super::*;
+    #[test]
+    fn parse_test_one() {
+        let m = "Yes Day (2021) [h265 WEBDL-1080p] [tt8521876]"
+            .parse::<Metadata>()
+            .unwrap();
+        assert_eq!(m.season(), None);
+        assert_eq!(m.episode(), None);
+        assert_eq!(m.imdb_tag(), Some("tt8521876"));
+        assert_eq!(m.year(), Some(2021));
+        assert_eq!(m.title(), "Yes Day");
+    }
+    #[test]
+    fn parse_test_two() {
+        let m: Metadata = "Yes Day (2021) [h265 WEBDL-1080p] [tt8521876]"
+            .parse()
+            .unwrap();
+        assert_eq!(m.season(), None);
+        assert_eq!(m.episode(), None);
+        assert_eq!(m.imdb_tag(), Some("tt8521876"));
+        assert_eq!(m.year(), Some(2021));
+        assert_eq!(m.title(), "Yes Day");
+    }
+}
 #[test]
 fn unicode() {
     Metadata::from("éé").unwrap();


### PR DESCRIPTION
Add Demo tests which can be called using cargo test::parse. Closes #12 
I do not know if this will impact the benchmarks. I have actually not gotten to benchmarking.

Purely optional. 