### PR TITLE
Add is_show and is_special methods as well as document Metadata::from

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -71,6 +71,19 @@ fn capture_to_string(caps: Option<Captures<'_>>) -> Option<String> {
 }
 
 impl Metadata {
+    ///```
+    /// use torrent_name_parser::Metadata;
+    ///
+    /// if let Ok(m) = Metadata::from("Doctor.Who.(2003).S01E01.avi") {
+    ///   assert_eq!(m.title(), "Doctor Who");
+    ///   assert_eq!(m.season(), Some(1));
+    ///   assert_eq!(m.extension(), Some("avi"));
+    ///   assert_eq!(m.is_show(), true);
+    ///   // Season is not 0 (zero) meaning it is not a Season Special. Eg: Christmas Special
+    ///   assert_eq!(m.is_special(), false);
+
+    /// }
+    ///```
     pub fn from(name: &str) -> Result<Self, ErrorMatch> {
         Metadata::from_str(name)
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -146,13 +146,7 @@ impl Metadata {
         self.season.is_some()
     }
     pub fn is_special(&self) -> bool {
-        if let Some(season) = self.season {
-            // Recode if season is converted back  to string
-            if season < 1 {
-                return true;
-            }
-        }
-        false
+        self.season.map(|s| s < 1).unwrap_or(false)
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -129,6 +129,18 @@ impl Metadata {
     pub fn extension(&self) -> Option<&str> {
         self.extension.as_deref()
     }
+    pub fn is_show(&self) -> bool {
+        self.season.is_some()
+    }
+    pub fn is_special(&self) -> bool {
+        if let Some(season) = self.season {
+            // Recode if season is converted back  to string
+            if season < 1 {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 impl FromStr for Metadata {

--- a/src/test.rs
+++ b/src/test.rs
@@ -423,31 +423,27 @@ mod extensions {
 }
 
 #[cfg(test)]
-mod parse {
-    use super::*;
+mod special {
+    use crate::metadata::Metadata;
+
     #[test]
-    fn parse_test_one() {
-        let m = "Yes Day (2021) [h265 WEBDL-1080p] [tt8521876]"
-            .parse::<Metadata>()
-            .unwrap();
-        assert_eq!(m.season(), None);
-        assert_eq!(m.episode(), None);
-        assert_eq!(m.imdb_tag(), Some("tt8521876"));
-        assert_eq!(m.year(), Some(2021));
-        assert_eq!(m.title(), "Yes Day");
+    fn special() {
+        // Support Files with file extension: avi, mkv, mp4
+        let m = Metadata::from("Life.on.Mars.(US).S01E01.avi").unwrap();
+        assert_eq!(m.title(), "Life on Mars");
+        assert_eq!(m.is_show(), true);
+        assert_eq!(m.is_special(), false);
     }
     #[test]
-    fn parse_test_two() {
-        let m: Metadata = "Yes Day (2021) [h265 WEBDL-1080p] [tt8521876]"
-            .parse()
-            .unwrap();
-        assert_eq!(m.season(), None);
-        assert_eq!(m.episode(), None);
-        assert_eq!(m.imdb_tag(), Some("tt8521876"));
-        assert_eq!(m.year(), Some(2021));
-        assert_eq!(m.title(), "Yes Day");
+    fn not_special() {
+        // detect special
+        let m = Metadata::from("Life.on.Mars.(US).S00E01.avi").unwrap();
+        assert_eq!(m.title(), "Life on Mars");
+        assert_eq!(m.is_show(), true);
+        assert_eq!(m.is_special(), true);
     }
 }
+
 #[test]
 fn unicode() {
     Metadata::from("éé").unwrap();


### PR DESCRIPTION
- Add is_show() function. References #18 
- Add is_special() function. References #18 
- Document Metadata::from() function
  - Provide code example in actual documentation. Tested as part of standard `cargo test` call.