### PR TITLE
Add support to detect country

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -292,7 +292,7 @@ impl FromStr for Metadata {
             name,
             &mut title_start,
             &mut title_end,
-            |caps| caps.get(1).map(|m| m.as_str()),
+            |caps| caps.name("country").map(|m| m.as_str()),
         )
         .map(String::from);
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -19,6 +19,7 @@ pub struct Metadata {
     codec: Option<String>,
     audio: Option<String>,
     group: Option<String>,
+    country: Option<String>,
     extended: bool,
     hardcoded: bool,
     proper: bool,
@@ -124,6 +125,9 @@ impl Metadata {
     }
     pub fn group(&self) -> Option<&str> {
         self.group.as_deref()
+    }
+    pub fn country(&self) -> Option<&str> {
+        self.country.as_deref()
     }
     pub fn imdb_tag(&self) -> Option<&str> {
         self.imdb.as_deref()
@@ -283,6 +287,14 @@ impl FromStr for Metadata {
             |caps| caps.get(1).map(|m| m.as_str()),
         )
         .map(String::from);
+        let country = check_pattern_and_extract(
+            &pattern::COUNTRY,
+            name,
+            &mut title_start,
+            &mut title_end,
+            |caps| caps.get(1).map(|m| m.as_str()),
+        )
+        .map(String::from);
 
         let extended = check_pattern(&pattern::EXTENDED, name, &mut title_start, &mut title_end);
         let hardcoded = check_pattern(&pattern::HARDCODED, name, &mut title_start, &mut title_end);
@@ -310,6 +322,7 @@ impl FromStr for Metadata {
                 ("codec", codec),
                 ("audio", audio),
                 ("group", group),
+                ("country", country),
                 ("imdb", imdb),
                 ("extended", capture_to_string(extended)),
                 ("proper", capture_to_string(proper)),
@@ -353,6 +366,7 @@ impl FromStr for Metadata {
             codec,
             audio,
             group,
+            country,
             extended: extended.is_some(),
             hardcoded: hardcoded.is_some(),
             proper: proper.is_some(),

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -105,7 +105,11 @@ lazy_static! {
     pub static ref AUDIO: Pattern =
         regex!(r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?");
     pub static ref GROUP: Pattern = regex!(r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$");
-    pub static ref COUNTRY: Pattern = regex!(r"(?i)\W[(]?(\w{2})[)]?\.S\d");
+    pub static ref COUNTRY: Pattern = regex!(
+        r"(?i)\W[(]?(?P<country>(?:U(?:A|G|K|M|S|Y|Z)|(?:A(?:D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z))|(?:B(?:A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z))|(?:C(?:A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z))|(?:D(?:E|J|K|M|O|Z))|
+(?:E(C|E|G|H|R|S|T))|(?:F(?:I|J|K|M|O|R))|(?:G(?:A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y))|(?:H(?:K|M|N|R|T|U))|(?:I(D|E|Q|L|M|N|O|R|S|T))|(?:J(?:E|M|O|P))|
+(?:K(E|G|H|I|M|N|P|R|W|Y|Z))|(?:L(?:A|B|C|I|K|R|S|T|U|V|Y))|(?:M(?:A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z))|(?:N(?:A|C|E|F|G|I|L|O|P|R|U|Z))|(?:OM)|(?:P(?:A|E|F|G|H|K|L|M|N|R|S|T|W|Y))|(?:QA)|(?:R(?:E|O|S|U|W))|(?:S(?:A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z))|(?:T(?:C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z))|(?:V(?:A|C|E|G|I|N|U))|(?:W(F|S))|(?:Y(E|T))|(?:Z(?:A|M|W))))[)]?\.S\d"
+    );
     pub static ref REGION: Pattern = regex!(r"R\d");
     pub static ref EXTENDED: Pattern = regex!(r"EXTENDED");
     pub static ref HARDCODED: Pattern = regex!(r"HC");

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -105,6 +105,7 @@ lazy_static! {
     pub static ref AUDIO: Pattern =
         regex!(r"MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)?|AC3(?:\.5\.1)?");
     pub static ref GROUP: Pattern = regex!(r"(- ?([^ -]+(?:-=\{[^ -]+-?$)?))$");
+    pub static ref COUNTRY: Pattern = regex!(r"(?i)\W[(]?(\w{2})[)]?\.S\d");
     pub static ref REGION: Pattern = regex!(r"R\d");
     pub static ref EXTENDED: Pattern = regex!(r"EXTENDED");
     pub static ref HARDCODED: Pattern = regex!(r"HC");

--- a/src/test.rs
+++ b/src/test.rs
@@ -39,6 +39,7 @@ fn names() {
     assert_eq!(m.resolution(), Some("1080p"));
     assert_eq!(m.title(), "Euphoria");
     assert_eq!(m.extension(), None);
+    assert_eq!(m.country(), Some("US"));
 
     let m = Metadata::from("narcos.s01e10.1080p.bluray.x264-rovers").unwrap();
     assert_eq!(m.season(), Some(1));
@@ -424,12 +425,14 @@ mod extensions {
         let m = Metadata::from("Life.on.Mars.(US).S01E01.avi").unwrap();
         assert_eq!(m.title(), "Life on Mars");
         assert_eq!(m.extension(), Some("avi"));
+        assert_eq!(m.country(), Some("US"));
     }
     #[test]
     fn m4v() {
-        let m = Metadata::from("Life.on.Mars.(US).S01E01.m4v").unwrap();
+        let m = Metadata::from("Life.on.Mars.(UK).S01E01.m4v").unwrap();
         assert_eq!(m.title(), "Life on Mars");
         assert_eq!(m.extension(), Some("m4v"));
+        assert_eq!(m.country(), Some("UK"));
     }
 }
 


### PR DESCRIPTION
Add the ability to detect two letter country codes.
*Note* The use of the `\d` in the regex pattern `r"(?i)\W[(]?(\w{2})[)]?\.S\d`

This is to prevent matches on names such as `Agents of S H I E L D` which occurred during testing.

It would be best to merge this pull request after #21 though there is no dependancy. Would simply merge conflict should one occur.

Closes #10 