### PR TITLE
Proof of concept to make extensions and other values enums 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,7 @@ mod pattern;
 #[cfg(test)]
 mod test;
 
+pub use metadata::extension::FileExtension;
+pub use metadata::extension::SubtitleExtension;
+pub use metadata::extension::VideoExtension;
 pub use metadata::Metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,4 @@ mod pattern;
 #[cfg(test)]
 mod test;
 
-pub use metadata::extension::FileExtension;
-pub use metadata::extension::SubtitleExtension;
-pub use metadata::extension::VideoExtension;
 pub use metadata::Metadata;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -81,7 +81,7 @@ impl Metadata {
     /// if let Ok(m) = Metadata::from("Doctor.Who.(2003).S01E01.avi") {
     ///   assert_eq!(m.title(), "Doctor Who");
     ///   assert_eq!(m.season(), Some(1));
-    ///   assert_eq!(m.extension(), Some(&FileExtension::Video(VideoExtension::AVI)));
+    ///   assert_eq!(m.extension(), Some(FileExtension::Video(VideoExtension::AVI)));
     ///   assert_eq!(m.extension().unwrap().to_string(), "avi");
     ///   assert_eq!(m.extension().unwrap().is_subtitle(), false);
     ///   assert_eq!(m.extension().unwrap().is_video(), true);
@@ -155,8 +155,8 @@ impl Metadata {
     pub fn three_d(&self) -> bool {
         self.three_d
     }
-    pub fn extension(&self) -> Option<&FileExtension> {
-        self.extension.as_ref()
+    pub fn extension(&self) -> Option<FileExtension> {
+        self.extension
     }
     pub fn is_show(&self) -> bool {
         self.season.is_some()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,6 @@
+pub mod extension;
 use crate::error::ErrorMatch;
+use crate::metadata::extension::FileExtension;
 use crate::pattern;
 use crate::pattern::Pattern;
 use regex::Captures;
@@ -27,7 +29,7 @@ pub struct Metadata {
     unrated: bool,
     three_d: bool,
     imdb: Option<String>,
-    extension: Option<String>,
+    extension: Option<FileExtension>,
 }
 
 fn check_pattern_and_extract<'a>(
@@ -74,11 +76,15 @@ fn capture_to_string(caps: Option<Captures<'_>>) -> Option<String> {
 impl Metadata {
     ///```
     /// use torrent_name_parser::Metadata;
+    /// use torrent_name_parser::{FileExtension, VideoExtension};
     ///
     /// if let Ok(m) = Metadata::from("Doctor.Who.(2003).S01E01.avi") {
     ///   assert_eq!(m.title(), "Doctor Who");
     ///   assert_eq!(m.season(), Some(1));
-    ///   assert_eq!(m.extension(), Some("avi"));
+    ///   assert_eq!(m.extension(), Some(&FileExtension::Video(VideoExtension::AVI)));
+    ///   assert_eq!(m.extension().unwrap().to_string(), "avi");
+    ///   assert_eq!(m.extension().unwrap().is_subtitle(), false);
+    ///   assert_eq!(m.extension().unwrap().is_video(), true);
     ///   assert_eq!(m.is_show(), true);
     ///   // Season is not 0 (zero) meaning it is not a Season Special. Eg: Christmas Special
     ///   assert_eq!(m.is_special(), false);
@@ -149,8 +155,8 @@ impl Metadata {
     pub fn three_d(&self) -> bool {
         self.three_d
     }
-    pub fn extension(&self) -> Option<&str> {
-        self.extension.as_deref()
+    pub fn extension(&self) -> Option<&FileExtension> {
+        self.extension.as_ref()
     }
     pub fn is_show(&self) -> bool {
         self.season.is_some()
@@ -361,7 +367,7 @@ impl FromStr for Metadata {
             unrated: unrated.is_some(),
             three_d: three_d.is_some(),
             imdb,
-            extension,
+            extension: extension.map(|s| s.parse::<FileExtension>().unwrap()),
         })
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -76,15 +76,12 @@ fn capture_to_string(caps: Option<Captures<'_>>) -> Option<String> {
 impl Metadata {
     ///```
     /// use torrent_name_parser::Metadata;
-    /// use torrent_name_parser::{FileExtension, VideoExtension};
     ///
     /// if let Ok(m) = Metadata::from("Doctor.Who.(2003).S01E01.avi") {
     ///   assert_eq!(m.title(), "Doctor Who");
     ///   assert_eq!(m.season(), Some(1));
-    ///   assert_eq!(m.extension(), Some(FileExtension::Video(VideoExtension::AVI)));
-    ///   assert_eq!(m.extension().unwrap().to_string(), "avi");
-    ///   assert_eq!(m.extension().unwrap().is_subtitle(), false);
-    ///   assert_eq!(m.extension().unwrap().is_video(), true);
+    ///   assert_eq!(m.extension(), Some("avi"));
+    ///   assert_eq!(m.ext_is_subtitle(), false);
     ///   assert_eq!(m.is_show(), true);
     ///   // Season is not 0 (zero) meaning it is not a Season Special. Eg: Christmas Special
     ///   assert_eq!(m.is_special(), false);

--- a/src/metadata/extension.rs
+++ b/src/metadata/extension.rs
@@ -1,0 +1,141 @@
+#[derive(Debug, Eq, PartialEq)]
+pub enum ExtensionError {
+    Err(String),
+}
+
+impl std::fmt::Display for ExtensionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtensionError::Err(s) => write!(f, "invalid file extension: {}", s),
+        }
+    }
+}
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum SubtitleExtension {
+    #[doc(hidden)]
+    SRT,
+    #[doc(hidden)]
+    SSA,
+    #[doc(hidden)]
+    SVB,
+    #[doc(hidden)]
+    VTT,
+}
+
+impl std::str::FromStr for SubtitleExtension {
+    type Err = ExtensionError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "srt" => Ok(Self::SRT),
+            "ssa" => Ok(Self::SSA),
+            "svb" => Ok(Self::SVB),
+            "vtt" => Ok(Self::VTT),
+            _ => Err(ExtensionError::Err(input.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for SubtitleExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubtitleExtension::SRT => write!(f, "srt"),
+            SubtitleExtension::SSA => write!(f, "ssa"),
+            SubtitleExtension::SVB => write!(f, "svb"),
+            SubtitleExtension::VTT => write!(f, "vtt"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum VideoExtension {
+    #[doc(hidden)]
+    AVI,
+    #[doc(hidden)]
+    M4V,
+}
+
+impl std::str::FromStr for VideoExtension {
+    type Err = ExtensionError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "avi" => Ok(Self::AVI),
+            "m4v" => Ok(Self::M4V),
+            _ => Err(ExtensionError::Err(input.to_owned())),
+        }
+    }
+}
+
+impl std::fmt::Display for VideoExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VideoExtension::AVI => write!(f, "avi"),
+            VideoExtension::M4V => write!(f, "m4v"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FileExtension {
+    #[doc(hidden)]
+    Subtitle(SubtitleExtension),
+    #[doc(hidden)]
+    Video(VideoExtension),
+}
+
+impl std::str::FromStr for FileExtension {
+    type Err = ExtensionError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input.to_ascii_lowercase().as_str() {
+            "srt" | "ssa" | "svb" | "vtt" => {
+                Ok(FileExtension::Subtitle(SubtitleExtension::from_str(input)?))
+            }
+            "m4v" | "avi" => Ok(FileExtension::Video(VideoExtension::from_str(input)?)),
+            _ => Err(ExtensionError::Err(input.to_owned())),
+        }
+    }
+}
+
+impl std::fmt::Display for FileExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileExtension::Subtitle(value) => write!(f, "{}", value),
+            FileExtension::Video(value) => write!(f, "{}", value),
+        }
+    }
+}
+impl FileExtension {
+    pub fn is_subtitle(&self) -> bool {
+        matches!(self, FileExtension::Subtitle(_))
+    }
+    pub fn is_video(&self) -> bool {
+        matches!(self, FileExtension::Video(_))
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn str() {
+    let ext: SubtitleExtension = "srt".parse().unwrap();
+    assert_eq!(ext.to_string(), "srt".to_string());
+    let ext: SubtitleExtension = "ssa".parse().unwrap();
+    assert_eq!(ext.to_string(), "ssa".to_string());
+    let ext: Result<SubtitleExtension, ExtensionError> = "test".parse();
+    assert_eq!(ext.is_err(), true);
+    let err = ext.unwrap_err();
+    assert_eq!(err.to_string(), "invalid file extension: test");
+
+    let ext: VideoExtension = "avi".parse().unwrap();
+    assert_eq!(ext.to_string(), "avi");
+    let ext: VideoExtension = "m4v".parse().unwrap();
+    assert_eq!(ext.to_string(), "m4v");
+
+    let ext: FileExtension = "srt".parse().unwrap();
+    assert_eq!(ext.is_subtitle(), true);
+    assert_eq!(ext.is_video(), false);
+    println!("{:?}", ext);
+    let ext: FileExtension = "avi".parse().unwrap();
+    assert_eq!(ext.is_subtitle(), false);
+    assert_eq!(ext.is_video(), true);
+    println!("{:?}", ext);
+    println!("test: {}", ext);
+}

--- a/src/metadata/extension.rs
+++ b/src/metadata/extension.rs
@@ -85,13 +85,12 @@ pub enum FileExtension {
 impl std::str::FromStr for FileExtension {
     type Err = ExtensionError;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input.to_ascii_lowercase().as_str() {
-            "srt" | "ssa" | "svb" | "vtt" => {
-                Ok(FileExtension::Subtitle(SubtitleExtension::from_str(input)?))
-            }
-            "m4v" | "avi" => Ok(FileExtension::Video(VideoExtension::from_str(input)?)),
-            _ => Err(ExtensionError::Err(input.to_owned())),
-        }
+        let lowered = input.to_ascii_lowercase();
+        lowered
+            .parse()
+            .map(FileExtension::Subtitle)
+            .or_else(|_| lowered.parse().map(FileExtension::Video))
+            .map_err(|_| ExtensionError::Err(input.to_string()))
     }
 }
 

--- a/src/metadata/extension.rs
+++ b/src/metadata/extension.rs
@@ -88,8 +88,8 @@ impl std::str::FromStr for FileExtension {
         let lowered = input.to_ascii_lowercase();
         lowered
             .parse()
-            .map(FileExtension::Subtitle)
-            .or_else(|_| lowered.parse().map(FileExtension::Video))
+            .map(FileExtension::Video)
+            .or_else(|_| lowered.parse().map(FileExtension::Subtitle))
             .map_err(|_| ExtensionError::Err(input.to_string()))
     }
 }

--- a/src/metadata/extension.rs
+++ b/src/metadata/extension.rs
@@ -10,7 +10,7 @@ impl std::fmt::Display for ExtensionError {
         }
     }
 }
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Copy, PartialEq, Eq, Clone)]
 pub enum SubtitleExtension {
     #[doc(hidden)]
     SRT,
@@ -46,7 +46,7 @@ impl std::fmt::Display for SubtitleExtension {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Copy, PartialEq, Eq, Clone)]
 pub enum VideoExtension {
     #[doc(hidden)]
     AVI,
@@ -74,7 +74,7 @@ impl std::fmt::Display for VideoExtension {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FileExtension {
     #[doc(hidden)]
     Subtitle(SubtitleExtension),

--- a/src/metadata/extension.rs
+++ b/src/metadata/extension.rs
@@ -1,140 +1,23 @@
-#[derive(Debug, Eq, PartialEq)]
-pub enum ExtensionError {
-    Err(String),
-}
-
-impl std::fmt::Display for ExtensionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExtensionError::Err(s) => write!(f, "invalid file extension: {}", s),
-        }
-    }
-}
-#[derive(Debug, Copy, PartialEq, Eq, Clone)]
-pub enum SubtitleExtension {
-    #[doc(hidden)]
-    SRT,
-    #[doc(hidden)]
-    SSA,
-    #[doc(hidden)]
-    SVB,
-    #[doc(hidden)]
-    VTT,
-}
-
-impl std::str::FromStr for SubtitleExtension {
-    type Err = ExtensionError;
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "srt" => Ok(Self::SRT),
-            "ssa" => Ok(Self::SSA),
-            "svb" => Ok(Self::SVB),
-            "vtt" => Ok(Self::VTT),
-            _ => Err(ExtensionError::Err(input.to_string())),
-        }
-    }
-}
-
-impl std::fmt::Display for SubtitleExtension {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SubtitleExtension::SRT => write!(f, "srt"),
-            SubtitleExtension::SSA => write!(f, "ssa"),
-            SubtitleExtension::SVB => write!(f, "svb"),
-            SubtitleExtension::VTT => write!(f, "vtt"),
-        }
-    }
-}
-
-#[derive(Debug, Copy, PartialEq, Eq, Clone)]
-pub enum VideoExtension {
-    #[doc(hidden)]
-    AVI,
-    #[doc(hidden)]
-    M4V,
-}
-
-impl std::str::FromStr for VideoExtension {
-    type Err = ExtensionError;
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            "avi" => Ok(Self::AVI),
-            "m4v" => Ok(Self::M4V),
-            _ => Err(ExtensionError::Err(input.to_owned())),
-        }
-    }
-}
-
-impl std::fmt::Display for VideoExtension {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VideoExtension::AVI => write!(f, "avi"),
-            VideoExtension::M4V => write!(f, "m4v"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum FileExtension {
-    #[doc(hidden)]
-    Subtitle(SubtitleExtension),
-    #[doc(hidden)]
-    Video(VideoExtension),
-}
-
-impl std::str::FromStr for FileExtension {
-    type Err = ExtensionError;
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let lowered = input.to_ascii_lowercase();
-        lowered
-            .parse()
-            .map(FileExtension::Video)
-            .or_else(|_| lowered.parse().map(FileExtension::Subtitle))
-            .map_err(|_| ExtensionError::Err(input.to_string()))
-    }
-}
-
-impl std::fmt::Display for FileExtension {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FileExtension::Subtitle(value) => write!(f, "{}", value),
-            FileExtension::Video(value) => write!(f, "{}", value),
-        }
-    }
-}
-impl FileExtension {
-    pub fn is_subtitle(&self) -> bool {
-        matches!(self, FileExtension::Subtitle(_))
-    }
-    pub fn is_video(&self) -> bool {
-        matches!(self, FileExtension::Video(_))
+pub(crate) fn set_is_subtitle(str: &str) -> bool {
+    match str.to_ascii_lowercase().as_str() {
+        "srt" | "ssa" | "svb" | "vtt" | "ttml" | "dfxp" => true,
+        _ => false,
     }
 }
 
 #[cfg(test)]
 #[test]
 fn str() {
-    let ext: SubtitleExtension = "srt".parse().unwrap();
-    assert_eq!(ext.to_string(), "srt".to_string());
-    let ext: SubtitleExtension = "ssa".parse().unwrap();
-    assert_eq!(ext.to_string(), "ssa".to_string());
-    let ext: Result<SubtitleExtension, ExtensionError> = "test".parse();
-    assert_eq!(ext.is_err(), true);
-    let err = ext.unwrap_err();
-    assert_eq!(err.to_string(), "invalid file extension: test");
-
-    let ext: VideoExtension = "avi".parse().unwrap();
-    assert_eq!(ext.to_string(), "avi");
-    let ext: VideoExtension = "m4v".parse().unwrap();
-    assert_eq!(ext.to_string(), "m4v");
-
-    let ext: FileExtension = "srt".parse().unwrap();
-    assert_eq!(ext.is_subtitle(), true);
-    assert_eq!(ext.is_video(), false);
-    println!("{:?}", ext);
-    let ext: FileExtension = "avi".parse().unwrap();
-    assert_eq!(ext.is_subtitle(), false);
-    assert_eq!(ext.is_video(), true);
-    println!("{:?}", ext);
-    println!("test: {}", ext);
+    let ext = set_is_subtitle("srt");
+    assert_eq!(ext, true);
+    let ext = set_is_subtitle("ssa");
+    assert_eq!(ext, true);
+    let ext = set_is_subtitle("svb");
+    assert_eq!(ext, true);
+    let ext = set_is_subtitle("vtt");
+    assert_eq!(ext, true);
+    let ext = set_is_subtitle("ttml");
+    assert_eq!(ext, true);
+    let ext = set_is_subtitle("DfXp");
+    assert_eq!(ext, true);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -407,7 +407,6 @@ fn names() {
 
 #[cfg(test)]
 mod extensions {
-    use crate::metadata::extension::{FileExtension, VideoExtension};
     use crate::metadata::Metadata;
 
     #[test]
@@ -424,19 +423,14 @@ mod extensions {
     fn avi() {
         let m = Metadata::from("Life.on.Mars.(US).S01E01.avi").unwrap();
         assert_eq!(m.title(), "Life on Mars");
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Video(VideoExtension::AVI))
-        );
+        assert_eq!(m.extension(), Some("avi"));
+        assert_eq!(m.ext_is_subtitle(), false);
     }
     #[test]
     fn m4v() {
         let m = Metadata::from("Life.on.Mars.(US).S01E01.m4v").unwrap();
         assert_eq!(m.title(), "Life on Mars");
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Video(VideoExtension::M4V))
-        );
+        assert_eq!(m.extension(), Some("m4v"));
     }
 }
 
@@ -585,56 +579,50 @@ mod multi_episodes {
     }
 }
 mod subtitle_extensions {
-    use crate::metadata::extension::{FileExtension, SubtitleExtension};
     use crate::metadata::Metadata;
 
     #[test]
     fn subtitle_srt() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.srt").unwrap();
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Subtitle(SubtitleExtension::SRT))
-        );
+        assert_eq!(m.extension(), Some("srt"));
+        assert_eq!(m.ext_is_subtitle(), true);
     }
     #[test]
     fn subtitle_ssa() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.ssa").unwrap();
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Subtitle(SubtitleExtension::SSA))
-        );
+        assert_eq!(m.extension(), Some("ssa"));
+        assert_eq!(m.ext_is_subtitle(), true);
     }
     #[test]
     fn subtitle_svb() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.svb").unwrap();
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Subtitle(SubtitleExtension::SVB))
-        );
+        assert_eq!(m.extension(), Some("svb"));
+        assert_eq!(m.ext_is_subtitle(), true);
     }
     #[test]
     fn subtitle_vtt() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.vtt").unwrap();
-        assert_eq!(
-            m.extension(),
-            Some(FileExtension::Subtitle(SubtitleExtension::VTT))
-        );
+        assert_eq!(m.extension(), Some("vtt"));
+        assert_eq!(m.ext_is_subtitle(), true);
     }
-    //    #[test]
-    //   fn subtitle_ttml() {
-    //       let m = Metadata::from("Life.on.Mars.(US).S00E01.ttml").unwrap();
-    //       assert_eq!(m.extension(), Some("ttml"));
-    //   }
-    //  #[test]
-    //    fn subtitle_dfxp() {
-    //       let m = Metadata::from("Life.on.Mars.(US).S00E01.dfxp").unwrap();
-    ////        assert_eq!(m.extension(), Some("dfxp"));
-    //   }
-    //  #[test]
-    //    fn subtitle_dfxp_mixed_sizes() {
-    //        let m = Metadata::from("Life.on.Mars.(US).S00E01.dFxP").unwrap();
-    //        assert_eq!(m.extension(), Some("dFxP"));
-    //    }
+    #[test]
+    fn subtitle_ttml() {
+        let m = Metadata::from("Life.on.Mars.(US).S00E01.ttml").unwrap();
+        assert_eq!(m.extension(), Some("ttml"));
+        assert_eq!(m.ext_is_subtitle(), true);
+    }
+    #[test]
+    fn subtitle_dfxp() {
+        let m = Metadata::from("Life.on.Mars.(US).S00E01.dfxp").unwrap();
+        assert_eq!(m.extension(), Some("dfxp"));
+        assert_eq!(m.ext_is_subtitle(), true);
+    }
+    #[test]
+    fn subtitle_dfxp_mixed_sizes() {
+        let m = Metadata::from("Life.on.Mars.(US).S00E01.dFxP").unwrap();
+        assert_eq!(m.extension(), Some("dFxP"));
+        assert_eq!(m.ext_is_subtitle(), true);
+    }
 }
 #[test]
 fn unicode() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -426,7 +426,7 @@ mod extensions {
         assert_eq!(m.title(), "Life on Mars");
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Video(VideoExtension::AVI))
+            Some(FileExtension::Video(VideoExtension::AVI))
         );
     }
     #[test]
@@ -435,7 +435,7 @@ mod extensions {
         assert_eq!(m.title(), "Life on Mars");
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Video(VideoExtension::M4V))
+            Some(FileExtension::Video(VideoExtension::M4V))
         );
     }
 }
@@ -593,7 +593,7 @@ mod subtitle_extensions {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.srt").unwrap();
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Subtitle(SubtitleExtension::SRT))
+            Some(FileExtension::Subtitle(SubtitleExtension::SRT))
         );
     }
     #[test]
@@ -601,7 +601,7 @@ mod subtitle_extensions {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.ssa").unwrap();
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Subtitle(SubtitleExtension::SSA))
+            Some(FileExtension::Subtitle(SubtitleExtension::SSA))
         );
     }
     #[test]
@@ -609,7 +609,7 @@ mod subtitle_extensions {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.svb").unwrap();
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Subtitle(SubtitleExtension::SVB))
+            Some(FileExtension::Subtitle(SubtitleExtension::SVB))
         );
     }
     #[test]
@@ -617,7 +617,7 @@ mod subtitle_extensions {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.vtt").unwrap();
         assert_eq!(
             m.extension(),
-            Some(&FileExtension::Subtitle(SubtitleExtension::VTT))
+            Some(FileExtension::Subtitle(SubtitleExtension::VTT))
         );
     }
     //    #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -407,6 +407,7 @@ fn names() {
 
 #[cfg(test)]
 mod extensions {
+    use crate::metadata::extension::{FileExtension, VideoExtension};
     use crate::metadata::Metadata;
 
     #[test]
@@ -423,13 +424,19 @@ mod extensions {
     fn avi() {
         let m = Metadata::from("Life.on.Mars.(US).S01E01.avi").unwrap();
         assert_eq!(m.title(), "Life on Mars");
-        assert_eq!(m.extension(), Some("avi"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Video(VideoExtension::AVI))
+        );
     }
     #[test]
     fn m4v() {
         let m = Metadata::from("Life.on.Mars.(US).S01E01.m4v").unwrap();
         assert_eq!(m.title(), "Life on Mars");
-        assert_eq!(m.extension(), Some("m4v"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Video(VideoExtension::M4V))
+        );
     }
 }
 
@@ -578,43 +585,56 @@ mod multi_episodes {
     }
 }
 mod subtitle_extensions {
+    use crate::metadata::extension::{FileExtension, SubtitleExtension};
     use crate::metadata::Metadata;
 
     #[test]
     fn subtitle_srt() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.srt").unwrap();
-        assert_eq!(m.extension(), Some("srt"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Subtitle(SubtitleExtension::SRT))
+        );
     }
     #[test]
     fn subtitle_ssa() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.ssa").unwrap();
-        assert_eq!(m.extension(), Some("ssa"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Subtitle(SubtitleExtension::SSA))
+        );
     }
     #[test]
     fn subtitle_svb() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.svb").unwrap();
-        assert_eq!(m.extension(), Some("svb"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Subtitle(SubtitleExtension::SVB))
+        );
     }
     #[test]
     fn subtitle_vtt() {
         let m = Metadata::from("Life.on.Mars.(US).S00E01.vtt").unwrap();
-        assert_eq!(m.extension(), Some("vtt"));
+        assert_eq!(
+            m.extension(),
+            Some(&FileExtension::Subtitle(SubtitleExtension::VTT))
+        );
     }
-    #[test]
-    fn subtitle_ttml() {
-        let m = Metadata::from("Life.on.Mars.(US).S00E01.ttml").unwrap();
-        assert_eq!(m.extension(), Some("ttml"));
-    }
-    #[test]
-    fn subtitle_dfxp() {
-        let m = Metadata::from("Life.on.Mars.(US).S00E01.dfxp").unwrap();
-        assert_eq!(m.extension(), Some("dfxp"));
-    }
-    #[test]
-    fn subtitle_dfxp_mixed_sizes() {
-        let m = Metadata::from("Life.on.Mars.(US).S00E01.dFxP").unwrap();
-        assert_eq!(m.extension(), Some("dFxP"));
-    }
+    //    #[test]
+    //   fn subtitle_ttml() {
+    //       let m = Metadata::from("Life.on.Mars.(US).S00E01.ttml").unwrap();
+    //       assert_eq!(m.extension(), Some("ttml"));
+    //   }
+    //  #[test]
+    //    fn subtitle_dfxp() {
+    //       let m = Metadata::from("Life.on.Mars.(US).S00E01.dfxp").unwrap();
+    ////        assert_eq!(m.extension(), Some("dfxp"));
+    //   }
+    //  #[test]
+    //    fn subtitle_dfxp_mixed_sizes() {
+    //        let m = Metadata::from("Life.on.Mars.(US).S00E01.dFxP").unwrap();
+    //        assert_eq!(m.extension(), Some("dFxP"));
+    //    }
 }
 #[test]
 fn unicode() {


### PR DESCRIPTION
The primary goal is to ensure a standardised value is returned for attributes that often vary wildly.

Note this is just proof of concept.
I am honestly thinking that using enums for things like `extension` `codec` `resolution` and more would make for a much cleaner and easier to use crate.

Crate users would not need to cleanup the `str` reference values because they get a clean consistent `enum` value to work with.

Thoughts @IGI-111 and @mcronce 